### PR TITLE
HasIcon bugfix

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -29,7 +29,7 @@ end
 --- @param username string The player's account name (e.g., "@m00nyONE").
 --- @return boolean hasStaticIcon `true` if a custom static icons exists, `false` otherwise.
 function lib.HasIcon(username)
-    return lib:HasStatic(username) or lib:HasAnimated(username)
+    return lib.HasStatic(username) or lib.HasAnimated(username)
 end
 
 


### PR DESCRIPTION
## Changes

- Fixed bug in HasIcon that caused it to incorrectly return false for all users

## Testing

```
d("PlayerName: " .. groupMemberName)
d("HasIcon: " .. tostring(Icons.HasIcon(groupMemberName)))
d("HasStatic: " .. tostring(Icons.HasStatic(groupMemberName)))
d("HasAnimated: " .. tostring(Icons.HasAnimated(groupMemberName)))
d("GetStatic: " .. Icons.GetStatic(groupMemberName))
d("getIcon ~= nil: " .. tostring(Icons.GetIcon ~= nil))
```

Before update:
<img width="539" height="336" alt="image" src="https://github.com/user-attachments/assets/4f55758e-1e2c-4bb3-8e89-43c3d6f8e957" />

After update:
<img width="515" height="309" alt="image" src="https://github.com/user-attachments/assets/03d774f1-4096-499c-951e-cae6ec93f37f" />
